### PR TITLE
Add missing libjpeg API header files (jpeglib.h, jmorecfg.h)

### DIFF
--- a/LibJpeg-Turbo.nuspec
+++ b/LibJpeg-Turbo.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>Libjpeg-Turbo</id>
 	<title>Libjpeg-Turbo 1.5.1</title>
-    <version>1.5.13</version>
+    <version>1.5.14</version>
     <authors>Scott Lee</authors>
     <owners>Scott Lee</owners>
     <licenseUrl>http://www.libjpeg-turbo.org/About/License</licenseUrl>

--- a/build.bat
+++ b/build.bat
@@ -12,6 +12,8 @@ mkdir ..\%dstnuget%\build\native\include
 copy jconfig.h ..\%dstnuget%\build\native\include
 copy jconfigint.h ..\%dstnuget%\build\native\include
 copy libjpeg-turbo\turbojpeg.h ..\%dstnuget%\build\native\include
+copy libjpeg-turbo\jmorecfg.h ..\%dstnuget%\build\native\include
+copy libjpeg-turbo\jpeglib.h ..\%dstnuget%\build\native\include
 
 call %msbuild% libjpeg-turbo-VS.sln /t:libjpeg-turbo-win32 /p:OutDir=../%dstnuget%/lib/native/v120/windesktop/msvcstl/Win32/Debug/md/ /p:Platform=x86 /p:PlatformToolset=v120 /p:Configuration=Debug_shared /p:RuntimeLibrary=MultiThreadedDebugDLL /p:DebugSymbols=true /p:DebugType=pdbonly
 call %msbuild% libjpeg-turbo-VS.sln /t:libjpeg-turbo-win32 /p:OutDir=../%dstnuget%/lib/native/v120/windesktop/msvcstl/Win32/Debug/mt/ /p:Platform=x86 /p:PlatformToolset=v120 /p:Configuration=Debug_static /p:RuntimeLibrary=MultiThreadedDebug /p:DebugSymbols=true /p:DebugType=pdbonly


### PR DESCRIPTION
libjpeg-turbo library includes both a high-performance implementation of the original libjpeg API , and the high-level TurboJPEG API. 

The headers required to use the original libjpeg API were missing in the nuget package.